### PR TITLE
2021-05-04-15-48-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Xanadu Change Log
 
+2021-05-04-15-48-16
+- Summary: Simplifying List Cards while adding options: Items Text, Items Image + Text, or a Table Row.
+- Removed three functions from moduleMeta class and each subclass. Replaced with sharable moduleMeta functions.
+- Added colMeta property widthForTable that defaults to empty string but can be overridden per Table Column Name.
+- Added two new moduleMeta getList functions: getListItem is for text, getListItemWImage is for an image + text, and getListRow is for html tables at full page width with a default column width.
+- Updated content-cards.php Lists for Contacts, Contact Picker ( image + text ), Settings-Users ( text ), and APIRequests ( html table ). It's now easy to change how Lists are displayed.
+
 2021-05-01-18-08-00
 - Added a link to the ChangeLog in the ReadMe.
 

--- a/app/apirequests/content-cards.php
+++ b/app/apirequests/content-cards.php
@@ -36,22 +36,24 @@ if ( true ) {
 		$cardHeaderContent .= ': ' . $recsList->rowCount;
 		$cardContent = '';
 		
-		// Mini Tables
+		// Items List
 		if ( $listStyle === 'items' ) {
 			$recsList->rowIndex = -1;
 			foreach ( $recsList->rowsD as $recsListRow ) {
 				$recsList->rowIndex++;
 				
+				// IDs
 				$idPrefix = $mmAPIRequestsT->NameModule . 'List';
+				$idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $mmAPIRequestsT->NameTableKey ];
+				$idListItemImage = $idListItem . 'Image';
+				
+				// Get List Item
 				$onClick = 'window.location.href = \'' . $mmAPIRequestsT->URLFull . $recsList->rowsD[ $recsList->rowIndex ][ $mmAPIRequestsT->NameTableKey ] . '\';';
-				$itemContent = $mmAPIRequestsT->getListItem( $idPrefix, $recsList, $onClick );
-				$itemID = $idPrefix . $recsList->rowsD[ $recsList->rowIndex ][ $mmAPIRequestsT->NameTableKey ];
-				$isSelected = ( $resp->reqID == $recsList->rowsD[ $recsList->rowIndex ][ $mmAPIRequestsT->NameTableKey ] ? true : false );
-				$cardContent .= $card->renderListItemLink( $itemContent, $recsList->rowIndex + 1, $itemID, $isSelected, $onClick );
+				$cardContent .= $mmAPIRequestsT->getListItem( $recsList, $idPrefix, $resp->reqID, $onClick );
 			}
 		}
 		
-		// Mini Tables
+		// Rows of Table
 		if ( $listStyle === 'rows' ) {
 			// Big Table
 			$tagsCellEmpty = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_MIDDLE ], [], [] );
@@ -59,7 +61,7 @@ if ( true ) {
 			
 			// Header
 			$recsList->rowIndex = 0;
-			$mmAPIRequestsT->getListRow( 'header', $recsList, $table, '', '', '', '', '' );
+			$mmAPIRequestsT->getListRow( 'head', $recsList, $table, '', '', '', '', '' );
 			
 			// Recs Loop
 			$recsList->rowIndex = -1;
@@ -68,7 +70,7 @@ if ( true ) {
 				
 				$idPrefix = $mmAPIRequestsT->NameModule . 'List';
 				$onClick = 'window.location.href = \'' . $mmAPIRequestsT->URLFull . $recsList->rowsD[ $recsList->rowIndex ][ $mmAPIRequestsT->NameTableKey ] . '\';';
-				$mmAPIRequestsT->getListRow( 'data', $recsList, $table, $idPrefix, $resp->reqID, $onClick, '75px', '100px' );
+				$mmAPIRequestsT->getListRow( 'body', $recsList, $table, $idPrefix, $resp->reqID, $onClick, '75px', '100px' );
 			}
 			
 			// Content

--- a/app/contacts/content-cards.php
+++ b/app/contacts/content-cards.php
@@ -2,9 +2,20 @@
 ///////////////////////////////////////////////////////////
 // List
 if ( true ) {
+	// List Style
+	$listStyle = 'items'; // items or rows
+	if ( $listStyle === 'items' ) {
+		$cardWidth = CARD_WIDTH;
+		$cardHeight = CARD_HEIGHT_MAX;
+	}
+	if ( $listStyle === 'rows' ) {
+		$cardWidth = '100%';
+		$cardHeight = '50rem';
+	}
+ 
 	// Card Init
 	$cardHeaderContent = $mmContactsT->FontAwesomeList . STR_NBSP . $mmContactsT->NamePlural;
-	$card = new \xan\eleCard( CARD_WIDTH, CARD_HEIGHT_MAX, true );
+	$card = new \xan\eleCard( $cardWidth, $cardHeight, true );
 	
 	// Query
 	$recsList = new \xan\recs( $mmContactsT );
@@ -14,7 +25,7 @@ if ( true ) {
 	$recsList->queryBindNamesA = $searchBarList[ 'queryBindNames' ];
 	$recsList->queryBindValuesA = $searchBarList[ 'queryBindValues' ];
 	$recsList->query();
-	$recsList->rowsMassageForGUI( true, [ 'NumberCurrency', 'DateContacted' ] );
+	$recsList->rowsMassageForGUI( true, [ 'NumberCurrency', 'ContactedDate' ] );
 	
 	// Error Check
 	if ( $recsList->errorB ) {
@@ -23,21 +34,55 @@ if ( true ) {
 		$cardHeaderContent .= ': None Found';
 	} else {
 		$cardHeaderContent .= ': ' . $recsList->rowCount;
-		
-		// Recs Loop
 		$cardContent = '';
-		$recsList->rowIndex = -1;
-		foreach ( $recsList->rowsD as $recsListRow ) {
-			$recsList->rowIndex++;
-			
-			$idPrefix = $mmContactsT->NameModule . 'List';
-			$onClick = 'window.location.href = \'' . $mmContactsT->URLFull . $recsList->rowsD[ $recsList->rowIndex ][ $mmContactsT->NameTableKey ] . '\';';
-			$itemContent = $mmContactsT->getListItem( $idPrefix, $recsList, $onClick );
-			$itemID = $idPrefix . $recsList->rowsD[ $recsList->rowIndex ][ $mmContactsT->NameTableKey ];
-			$isSelected = ( $resp->reqID == $recsList->rowsD[ $recsList->rowIndex ][ $mmContactsT->NameTableKey ] ? true : false );
-			$cardContent .= $card->renderListItemLink( $itemContent, $recsList->rowIndex + 1, $itemID, $isSelected, $onClick );
-			
+		
+		if ( $listStyle === 'items' ) {
+			$recsList->rowIndex = -1;
+			foreach ( $recsList->rowsD as $recsListRow ) {
+				$recsList->rowIndex++;
+				
+				// IDs
+				$idPrefix = $mmContactsT->NameModule . 'List';
+				$idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $mmContactsT->NameTableKey ];
+				$idListItemImage = $idListItem . 'Image';
+				
+				// Image Element
+				$imgURL = \xan\fileBucketURL( $mmContactsT->NameTable, $recsList->rowsD[ $recsList->rowIndex ][ $mmContactsT->NameTableKey ], 'PhotoFN', $recsList->rowsD[ $recsList->rowIndex ][ 'PhotoFN' ] );
+				$tagsEleImage = new \xan\tags( [ 'img-thumbnail' ], [ 'max-width' => '4rem', 'max-height' => '100%' ], [] );
+				$imgEle = new \xan\eleURLImage( $imgURL, ( $recsList->rowIndex > 20 ? true : false ), $idListItemImage, 'Photo', 'Photo', $tagsEleImage );
+				$tagsCellImage = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], array( 'width' => '4.2rem' ), [] );
+				
+				// Get List Item
+				$onClick = 'window.location.href = \'' . $mmContactsT->URLFull . $recsList->rowsD[ $recsList->rowIndex ][ $mmContactsT->NameTableKey ] . '\';';
+				// $cardContent .= $mmContactsT->getListItem( $recsList, $idPrefix, $resp->reqID, $onClick );
+				$cardContent .= $mmContactsT->getListItemWImage( $recsList, $idPrefix, $resp->reqID, $onClick, $tagsCellImage, $imgEle );
+			}
 		}
+		
+		// Rows of Table
+		if ( $listStyle === 'rows' ) {
+			// Big Table
+			$tagsCellEmpty = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_MIDDLE ], [], [] );
+			$table = new \xan\eleTable( $tagsCellEmpty );
+			
+			// Header
+			$recsList->rowIndex = 0;
+			$mmContactsT->getListRow( 'head', $recsList, $table, '', '', '', '', '' );
+			
+			// Recs Loop
+			$recsList->rowIndex = -1;
+			foreach ( $recsList->rowsD as $recsListRow ) {
+				$recsList->rowIndex++;
+				
+				$idPrefix = $mmContactsT->NameModule . 'List';
+				$onClick = 'window.location.href = \'' . $mmContactsT->URLFull . $recsList->rowsD[ $recsList->rowIndex ][ $mmContactsT->NameTableKey ] . '\';';
+				$mmContactsT->getListRow( 'body', $recsList, $table, $idPrefix, $resp->reqID, $onClick, '75px', '100px' );
+			}
+			
+			// Content
+			$cardContent .= $table->render( 1 );
+		}
+		
 	}
 	
 	// Header Button New Record

--- a/app/contacts/do-contacts-picker.php
+++ b/app/contacts/do-contacts-picker.php
@@ -27,7 +27,7 @@ $cardTemp = new \xan\eleCard( '', '', '' );
 
 // Query Search Term Prep
 $queryColumns = array( 'NameCompany', 'NameFirst', 'NameLast' );
-$queryWhere = ( \xan\isEmpty( $doParam[ 'SearchTerm' ] ) ? '' : 'AND ( ' . \xan\dbSearchTermSQL( $queryColumns ) . ' )' );
+$queryWhere = ( \xan\isEmpty( $doParam[ 'SearchTerm' ] ) ? '' : '( ' . \xan\dbSearchTermSQL( $queryColumns ) . ' )' );
 $queryTermBindNamesA = ( \xan\isEmpty( $doParam[ 'SearchTerm' ] ) ? array() : \xan\dbSearchTermBindNamesA( $queryColumns ) );
 $queryTermBindValuesA = ( \xan\isEmpty( $doParam[ 'SearchTerm' ] ) ? array() : \xan\dbSearchTermBindValuesA( $queryColumns, $doParam[ 'SearchTerm' ] ) );
 
@@ -51,10 +51,19 @@ if ( $recs->errorB ) {
 	foreach ( $recs->rowsD as $recsListRow ) {
 		$recs->rowIndex++;
 		
+		// IDs
+		$idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $mmContactsT->NameTableKey ];
+		$idListItemImage = $idListItem . 'Image';
+		
+		// Image Element
+		$imgURL = \xan\fileBucketURL( $mmContactsT->NameTable, $recs->rowsD[ $recs->rowIndex ][ $mmContactsT->NameTableKey ], 'PhotoFN', $recs->rowsD[ $recs->rowIndex ][ 'PhotoFN' ] );
+		$tagsEleImage = new \xan\tags( [ 'img-thumbnail' ], [ 'max-width' => '4rem', 'max-height' => '100%' ], [] );
+		$imgEle = new \xan\eleURLImage( $imgURL, ( $recs->rowIndex > 20 ? true : false ), $idListItemImage, 'Photo', 'Photo', $tagsEleImage );
+		$tagsCellImage = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], array( 'width' => '4.2rem' ), [] );
+		
+		// Get List Item
 		$onClick = '$(\'#' . $idPrefix . '_Modal\').modal(\'hide\'); alert( \'' . $recsListRow[ $mmContactsT->NameTableKey ] . '\');';
-		$itemContent = $mmContactsT->getListItem( $idPrefix, $recs, $onClick );
-		$itemID = $idPrefix . $recsListRow[ $mmContactsT->NameTableKey ];
-		$cardListContent .= $cardTemp->renderListItemLink( $itemContent, $recs->rowIndex + 1, $itemID, false, $onClick );
+		$cardListContent .= $mmContactsT->getListItemWImage( $recs, $idPrefix, '', $onClick, $tagsCellImage, $imgEle );
 	}
 }
 

--- a/app/settings-users/content-cards.php
+++ b/app/settings-users/content-cards.php
@@ -2,9 +2,20 @@
 ///////////////////////////////////////////////////////////
 // List
 if ( true ) {
+	// List Style
+	$listStyle = 'items'; // items or rows
+	if ( $listStyle === 'items' ) {
+		$cardWidth = CARD_WIDTH;
+		$cardHeight = CARD_HEIGHT_MAX;
+	}
+	if ( $listStyle === 'rows' ) {
+		$cardWidth = '100%';
+		$cardHeight = '50rem';
+	}
+	
 	// Card Init
 	$cardHeaderContent = $mmUsersT->FontAwesomeList . STR_NBSP . $mmUsersT->NamePlural;
-	$card = new \xan\eleCard( CARD_WIDTH, CARD_HEIGHT_MAX, true );
+	$card = new \xan\eleCard( $cardWidth, $cardHeight, true );
 	
 	// Query
 	$recsList = new \xan\recs( $mmUsersT );
@@ -23,21 +34,49 @@ if ( true ) {
 		$cardHeaderContent .= ': None Found';
 	} else {
 		$cardHeaderContent .= ': ' . $recsList->rowCount;
-		
-		// Recs Loop
 		$cardContent = '';
-		$recsList->rowIndex = -1;
-		foreach ( $recsList->rowsD as $recsListRow ) {
-			$recsList->rowIndex++;
-			
-			$idPrefix = $mmUsersT->NameModule . 'List';
-			$onClick = 'window.location.href = \'' . $mmUsersT->URLFull . $recsList->rowsD[ $recsList->rowIndex ][ $mmUsersT->NameTableKey ] . '\';';
-			$itemContent = $mmUsersT->getListItem( $idPrefix, $recsList, $onClick );
-			$itemID = $idPrefix . $recsList->rowsD[ $recsList->rowIndex ][ $mmUsersT->NameTableKey ];
-			$isSelected = ( $resp->reqID == $recsList->rowsD[ $recsList->rowIndex ][ $mmUsersT->NameTableKey ] ? true : false );
-			$cardContent .= $card->renderListItemLink( $itemContent, $recsList->rowIndex + 1, $itemID, $isSelected, $onClick );
-			
+		
+		// Items List
+		if ( $listStyle === 'items' ) {
+			$recsList->rowIndex = -1;
+			foreach ( $recsList->rowsD as $recsListRow ) {
+				$recsList->rowIndex++;
+				
+				// IDs
+				$idPrefix = $mmUsersT->NameModule . 'List';
+				$idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $mmUsersT->NameTableKey ];
+				$idListItemImage = $idListItem . 'Image';
+				
+				// Get List Item
+				$onClick = 'window.location.href = \'' . $mmUsersT->URLFull . $recsList->rowsD[ $recsList->rowIndex ][ $mmUsersT->NameTableKey ] . '\';';
+				$cardContent .= $mmUsersT->getListItem( $recsList, $idPrefix, $resp->reqID, $onClick );
+			}
 		}
+		
+		// Rows of Table
+		if ( $listStyle === 'rows' ) {
+			// Big Table
+			$tagsCellEmpty = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_MIDDLE ], [], [] );
+			$table = new \xan\eleTable( $tagsCellEmpty );
+			
+			// Header
+			$recsList->rowIndex = 0;
+			$mmUsersT->getListRow( 'head', $recsList, $table, '', '', '', '', '' );
+			
+			// Recs Loop
+			$recsList->rowIndex = -1;
+			foreach ( $recsList->rowsD as $recsListRow ) {
+				$recsList->rowIndex++;
+				
+				$idPrefix = $mmUsersT->NameModule . 'List';
+				$onClick = 'window.location.href = \'' . $mmUsersT->URLFull . $recsList->rowsD[ $recsList->rowIndex ][ $mmUsersT->NameTableKey ] . '\';';
+				$mmUsersT->getListRow( 'body', $recsList, $table, $idPrefix, $resp->reqID, $onClick, '75px', '100px' );
+			}
+			
+			// Content
+			$cardContent .= $table->render( 1 );
+		}
+		
 	}
 	
 	// Header Button New Record

--- a/app/zzMetaModules/mmAPIRequestsT.php
+++ b/app/zzMetaModules/mmAPIRequestsT.php
@@ -33,7 +33,7 @@ class moduleMetaAPIRequestsT extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayName( \xan\recs $recs ) {
 		$code = trim( $recs->rowsD[ $recs->rowIndex ][ 'RequestTS' ] . " " . $recs->rowsD[ $recs->rowIndex ][ 'Auth' ] . " " . $recs->rowsD[ $recs->rowIndex ][ 'Action' ] . " " . $recs->rowsD[ $recs->rowIndex ][ 'ActionID' ] );
@@ -47,93 +47,6 @@ class moduleMetaAPIRequestsT extends \xan\moduleMeta {
 		
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ];
-		$idListItemImage = $idListItem . 'Image';
-		$idListItemLabel = $idListItem . 'Label';
-		
-		// Table Init
-		$tagsCellEmpty = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_MIDDLE ], [], [] );
-		$tagsCellRightMiddle = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [], [] );
-		$table = new \xan\eleTable( $tagsCellEmpty );
-		
-		// Table Cell
-		$info = '<span id="' . $idListItemLabel . '" class="list-group-item-text">' . $this->getDisplayList( $recs ) . '</span>';
-		$table->cellSet( $recs->rowIndex, 0, $tagsCellRightMiddle, $info );
-		
-		// Content
-		$code = $table->render();
-		return $code;
-	}
-	
-	public function getListRow( $rowType, \xan\recs $recs, \xan\eleTable &$table, $dataIDPrefix, $dataIDSelected, $dataOnClick, $dataRowHeight, $dataColWidth ) {
-		if ( $rowType === 'header' ) {
-			// Init Indexes
-			$colIndex = 0;
-			
-			// Cell Tag
-			$tagsCell = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [ 'position' => '-webkit-sticky', 'position' => '-moz-sticky', 'position' => '-ms-sticky', 'position' => '-o-sticky', 'position' => 'sticky', 'top' => 0 ], [] );
-			
-			// Cell Left
-			$table->cellSet( $recs->rowIndex, $colIndex, $tagsCell, '' );
-		}
-		
-		if ( $rowType === 'data' ) {
-			// Init Indexes
-			$colIndex = 0;
-			$rowIndexTable = $recs->rowIndex + 1;
-			
-			// Cell Tag
-			$isActive = ( $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ] === $dataIDSelected ? 'active' : '' );
-			$tagsCell = new \xan\tags( [ $isActive, 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [], [] );
-			
-			// Cell Left
-			$idListItem = $dataIDPrefix . $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ];
-			$buttonMoreTags = new \xan\tags( [ ELE_CLASS_BUTTON_SM_SECONDARY, 'mb-2' ], [], [ 'id="' . $idListItem . '"', 'onclick="window.location.href = \'' . $this->URLFull . $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ] . '\';"' ] );
-			$buttonMoreEle = new \xan\eleButton( $rowIndexTable, '', '', $buttonMoreTags );
-			$table->cellSet( $rowIndexTable, $colIndex, $tagsCell, '<div style="height: ' . $dataRowHeight . '; overflow-y: auto;">' . $buttonMoreEle->render() . '</div>' );
-		}
-		
-		// For Each Header or Data Row Cell
-		foreach ( $recs->rowsD[ $recs->rowIndex ] as $key => $value ) {
-			$colIndex++;
-			
-			// Column Width Overrides
-			switch ( $key ) {
-				case 'RequestData':
-					$width = '400px';
-					break;
-				case 'ResponseURL':
-					$width = '200px';
-					break;
-				case 'ResponseData':
-					$width = '500px';
-					break;
-				case 'Log':
-					$width = '300px';
-					break;
-				default:
-					$width = $dataColWidth;
-			}
-			
-			if ( $rowType === 'header' ) {
-				$headerLabelColMeta = $this->getColMeta( $key );
-				$table->cellSet( $recs->rowIndex, $colIndex, $tagsCell, $headerLabelColMeta->colLabel );
-			}
-			
-			if ( $rowType === 'data' ) {
-				$table->cellSet( $rowIndexTable, $colIndex, $tagsCell, '<div style="height: ' . $dataRowHeight . '; width: ' . $width . '; overflow-y: auto;">' . $value . '</div>' );
-			}
-		}
-		
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -151,6 +64,9 @@ class moduleMetaAPIRequestsT extends \xan\moduleMeta {
 		$colMeta->choicesADisplay = [];
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
+		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
 		
 		// Columns Specifics
 		switch ( $colName ) {
@@ -184,6 +100,7 @@ class moduleMetaAPIRequestsT extends \xan\moduleMeta {
 			case 'RequestData':
 				$colMeta->colLabelEN = 'Request Data';
 				$colMeta->eleType = ELE_TYPE_TEXTAREA_DB;
+				$colMeta->widthForTable = '400px';
 				break;
 			case 'ResponseTS':
 				$colMeta->colLabelEN = 'Response TS';
@@ -199,9 +116,11 @@ class moduleMetaAPIRequestsT extends \xan\moduleMeta {
 			case 'ResponseData':
 				$colMeta->colLabelEN = 'Response Data';
 				$colMeta->eleType = ELE_TYPE_TEXTAREA_DB;
+				$colMeta->widthForTable = '500px';
 				break;
 			case 'ResponseURL':
 				$colMeta->colLabelEN = 'Response URL';
+				$colMeta->widthForTable = '200px';
 				break;
 			case 'ResponseAuth':
 				$colMeta->colLabelEN = 'Response Auth';
@@ -214,6 +133,7 @@ class moduleMetaAPIRequestsT extends \xan\moduleMeta {
 				break;
 			case 'Log':
 				$colMeta->colLabelEN = 'Log';
+				$colMeta->widthForTable = '300px';
 				break;
 			
 			// UUID
@@ -230,13 +150,6 @@ class moduleMetaAPIRequestsT extends \xan\moduleMeta {
 		
 		// Return the Element
 		return $colMeta;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
 	}
 	
 	

--- a/app/zzMetaModules/mmCheckout.php
+++ b/app/zzMetaModules/mmCheckout.php
@@ -30,7 +30,7 @@ class moduleMetaCheckout extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -42,17 +42,6 @@ class moduleMetaCheckout extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -71,10 +60,13 @@ class moduleMetaCheckout extends \xan\moduleMeta {
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
 		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'NULL':
-				$colEle->colLabelEN = 'NULL';
+				$colMeta->colLabelEN = 'NULL';
 				break;
 		}
 		
@@ -83,13 +75,6 @@ class moduleMetaCheckout extends \xan\moduleMeta {
 		
 		// Return the Element
 		return $colMeta;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
 	}
 	
 	

--- a/app/zzMetaModules/mmContactsCommsT.php
+++ b/app/zzMetaModules/mmContactsCommsT.php
@@ -33,7 +33,7 @@ class moduleMetaContactsCommsT extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -47,125 +47,110 @@ class moduleMetaContactsCommsT extends \xan\moduleMeta {
 		return $code;
 	}
 	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
-	}
-	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
 		// Init
-		$colEle = new \xan\colMeta();
-		$colEle->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
-		$colEle->eleTypeAs = $typeAs;
-		$colEle->colName = $colName;
-		$colEle->colLabelEN = $colEle->colName;
-		$colEle->colLabel = $colEle->colName;
+		$colMeta = new \xan\colMeta();
+		$colMeta->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
+		$colMeta->eleTypeAs = $typeAs;
+		$colMeta->colName = $colName;
+		$colMeta->colLabelEN = $colMeta->colName;
+		$colMeta->colLabel = $colMeta->colName;
 		
 		// Choices
-		$colEle->choicesAValues = [];
-		$colEle->choicesADisplay = [];
-		$colEle->choicesClearLabel = STR_CLEAR; // Add Clear
-		$colEle->choicesOtherLabel = STR_OTHER; // Add Other
+		$colMeta->choicesAValues = [];
+		$colMeta->choicesADisplay = [];
+		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
+		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
+		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
 		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'Type':
-				$colEle->colLabelEN = 'Type';
-				$colEle->eleType = ELE_TYPE_SELECT_DB;
+				$colMeta->colLabelEN = 'Type';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
 				$arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `Type` From ContactsComms WHERE LENGTH( `Type` ) > 0 ORDER BY `Type` ASC" );
-				$colEle->choicesAValues = $arrays[ 0 ];
-				$colEle->choicesADisplay = $arrays[ 0 ];
+				$colMeta->choicesAValues = $arrays[ 0 ];
+				$colMeta->choicesADisplay = $arrays[ 0 ];
 				break;
 			case 'Label':
-				$colEle->colLabelEN = 'Label';
-				$colEle->eleType = ELE_TYPE_SELECT_DB;
+				$colMeta->colLabelEN = 'Label';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
 				$arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `Label` From ContactsComms WHERE LENGTH( `Label` ) > 0 ORDER BY `Label` ASC" );
-				$colEle->choicesAValues = $arrays[ 0 ];
-				$colEle->choicesADisplay = $arrays[ 0 ];
+				$colMeta->choicesAValues = $arrays[ 0 ];
+				$colMeta->choicesADisplay = $arrays[ 0 ];
 				break;
 			case 'Main':
-				$colEle->colLabelEN = 'Main';
-				$colEle->eleType = ELE_TYPE_SELECT_DB;
-				$colEle->choicesAValues = ARRAY_YESNO;
-				$colEle->choicesADisplay = ARRAY_YESNO;
-				$colEle->choicesOtherLabel = '';
+				$colMeta->colLabelEN = 'Main';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
+				$colMeta->choicesAValues = ARRAY_YESNO;
+				$colMeta->choicesADisplay = ARRAY_YESNO;
+				$colMeta->choicesOtherLabel = '';
 				break;
 			case 'Data':
-				$colEle->colLabelEN = 'Data';
+				$colMeta->colLabelEN = 'Data';
 				break;
 			case 'AddressStreet':
-				$colEle->colLabelEN = 'Street';
+				$colMeta->colLabelEN = 'Street';
 				break;
 			case 'AddressCity':
-				$colEle->colLabelEN = 'City';
+				$colMeta->colLabelEN = 'City';
 				break;
 			case 'AddressState':
-				$colEle->colLabelEN = 'State';
+				$colMeta->colLabelEN = 'State';
 				break;
 			case 'AddressZip':
-				$colEle->colLabelEN = 'Zip';
+				$colMeta->colLabelEN = 'Zip';
 				break;
 			case 'AddressCounty':
-				$colEle->colLabelEN = 'County';
+				$colMeta->colLabelEN = 'County';
 				break;
 			case 'AddressCountry':
-				$colEle->colLabelEN = 'Country';
+				$colMeta->colLabelEN = 'Country';
 				break;
 			case 'AddressLatitude':
-				$colEle->colLabelEN = 'Latitude';
+				$colMeta->colLabelEN = 'Latitude';
 				break;
 			case 'AddressLongitude':
-				$colEle->colLabelEN = 'Longitude';
+				$colMeta->colLabelEN = 'Longitude';
 				break;
 			
 			// Mod
 			case 'ModTS':
-				$colEle->colLabelEN = 'Mod TS';
-				$colEle->isMod = true;
+				$colMeta->colLabelEN = 'Mod TS';
+				$colMeta->isMod = true;
 				break;
 			case 'ModName':
-				$colEle->colLabelEN = 'Mod Name';
-				$colEle->isMod = true;
+				$colMeta->colLabelEN = 'Mod Name';
+				$colMeta->isMod = true;
 				break;
 			case 'ModUUIDUsers':
-				$colEle->colLabelEN = 'Mod Users ID';
-				$colEle->isMod = true;
-				$colEle->isKey = true;
+				$colMeta->colLabelEN = 'Mod Users ID';
+				$colMeta->isMod = true;
+				$colMeta->isKey = true;
 				break;
 			
 			// UUID
 			case 'UUIDContactsComms':
-				$colEle->colLabelEN = 'Comms ID';
-				$colEle->isKey = true;
-				$colEle->isKeyPrimary = true;
-				$colEle->isKeyForeign = false;
+				$colMeta->colLabelEN = 'Comms ID';
+				$colMeta->isKey = true;
+				$colMeta->isKeyPrimary = true;
+				$colMeta->isKeyForeign = false;
 				break;
 			case 'UUIDContacts':
-				$colEle->colLabelEN = 'Contacts ID';
-				$colEle->isKey = true;
-				$colEle->isKeyPrimary = false;
-				$colEle->isKeyForeign = true;
+				$colMeta->colLabelEN = 'Contacts ID';
+				$colMeta->isKey = true;
+				$colMeta->isKeyPrimary = false;
+				$colMeta->isKeyForeign = true;
 				break;
 		}
 		
 		// Set the Label
-		$colEle->colLabel = $colEle->colLabelEN;
+		$colMeta->colLabel = $colMeta->colLabelEN;
 		
 		// Return the Element
-		return $colEle;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colEle, $tags, $recs, $formTag, $resp );
-		return $code;
+		return $colMeta;
 	}
 	
 	

--- a/app/zzMetaModules/mmContactsT.php
+++ b/app/zzMetaModules/mmContactsT.php
@@ -1,39 +1,39 @@
 <?php
 
 class moduleMetaContactsT extends \xan\moduleMeta {
-    // Constructor
-    public function __construct() {
-        parent::__construct();
-        $this->NameModule = 'Contacts';
-        $this->NameModuleLower = strtolower( $this->NameModule );
-        $this->NameTable = 'Contacts';
-        $this->NameTableKey = 'UUIDContacts';
+	// Constructor
+	public function __construct() {
+		parent::__construct();
+		$this->NameModule = 'Contacts';
+		$this->NameModuleLower = strtolower( $this->NameModule );
+		$this->NameTable = 'Contacts';
+		$this->NameTableKey = 'UUIDContacts';
 		$this->NameTableParam = \xan\strSubstitute( $this->NameTableKey, 'UU', '' );
-
-        // QueryBuilder Operators: equal, not_equal, in, not_in, less, less_or_equal, greater, greater_or_equal, between, not_between, begins_with, not_begins_with, contains, not_contains, ends_with, not_ends_with, is_empty, is_not_empty, is_null, is_not_null
-        $this->QuerySimpleDefault = array( 'NameCompany', 'NameFirst', 'NameLast' );
-        $this->QueryBuilderDefault = '{ field: "Contacts.NameCompany", id: "querybuilder_Contacts_NameCompany", operator: "begins_with", value: "" }';
-
-        $this->QueryOrderByDefault = 'NameCompany ASC, NameLast ASC, NameFirst ASC';
-        $this->QueryOrderByExtraBegin .= \xan\dbQueryOrderByItem( $this->NameTable, 'NameCompany ASC, NameLast ASC, NameFirst ASC', 'NameCompany DESC, NameLast DESC, NameFirst DESC', 'Company, Last, First' );
-        $this->QueryOrderByExtraBegin .= '<hr />';
-
-        $this->NamePlural = 'Contacts';
-        $this->NameSingular = 'Contact';
-
-        $this->FontAwesome = '<i class=\'fas fa-user\'></i>';
-        $this->FontAwesomeList = FA_LIST;
-
-        $this->URLRelative = '/' . 'contacts/';
-        $this->URLFull = URL_BASE . 'contacts/';
-	
+		
+		// QueryBuilder Operators: equal, not_equal, in, not_in, less, less_or_equal, greater, greater_or_equal, between, not_between, begins_with, not_begins_with, contains, not_contains, ends_with, not_ends_with, is_empty, is_not_empty, is_null, is_not_null
+		$this->QuerySimpleDefault = array( 'NameCompany', 'NameFirst', 'NameLast' );
+		$this->QueryBuilderDefault = '{ field: "Contacts.NameCompany", id: "querybuilder_Contacts_NameCompany", operator: "begins_with", value: "" }';
+		
+		$this->QueryOrderByDefault = 'NameCompany ASC, NameLast ASC, NameFirst ASC';
+		$this->QueryOrderByExtraBegin .= \xan\dbQueryOrderByItem( $this->NameTable, 'NameCompany ASC, NameLast ASC, NameFirst ASC', 'NameCompany DESC, NameLast DESC, NameFirst DESC', 'Company, Last, First' );
+		$this->QueryOrderByExtraBegin .= '<hr />';
+		
+		$this->NamePlural = 'Contacts';
+		$this->NameSingular = 'Contact';
+		
+		$this->FontAwesome = '<i class=\'fas fa-user\'></i>';
+		$this->FontAwesomeList = FA_LIST;
+		
+		$this->URLRelative = '/' . 'contacts/';
+		$this->URLFull = URL_BASE . 'contacts/';
+		
 		$this->URLDoRelative = '/' . 'contacts-do/';
 		$this->URLDoFull = URL_BASE . 'contacts-do/';
-    }
-
-
-    ///////////////////////////////////////////////////////////
-    // Functions Required by \xan\moduleMeta
+	}
+	
+	
+	///////////////////////////////////////////////////////////
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayName( \xan\recs $recs ) {
 		// Name
@@ -48,7 +48,9 @@ class moduleMetaContactsT extends \xan\moduleMeta {
 	}
 	
 	public function getDisplayList( \xan\recs $recs ) {
+		// Name
 		$code = $this->getDisplayName( $recs );
+		// More
 		$code .= ( \xan\isEmpty( $recs->rowsD[ $recs->rowIndex ][ 'Status' ] ) ? '' : ', ' . $recs->rowsD[ $recs->rowIndex ][ 'Status' ] );
 		$code .= ( \xan\isEmpty( $recs->rowsD[ $recs->rowIndex ][ 'Type' ] ) ? '' : ', ' . $recs->rowsD[ $recs->rowIndex ][ 'Type' ] );
 		
@@ -56,208 +58,172 @@ class moduleMetaContactsT extends \xan\moduleMeta {
 		return $code;
 	}
 	
-    public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-        $idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ];
-        $idListItemImage = $idListItem . 'Image';
-        $idListItemLabel = $idListItem . 'Label';
-
-        // Table Init
-        $tagsCellEmpty = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_MIDDLE ], [], [] );
-        $tagsCellPhoto = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], array( 'width' => '4.2rem' ), [] );
-        $tagsEleInput_Photo = new \xan\tags( [ 'img-thumbnail' ], [ 'max-width' => '4rem', 'max-height' => '100%' ], [] );
-        $tagsCellRightMiddle = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [], [] );
-        $table = new \xan\eleTable( $tagsCellEmpty );
-
-        // Image Cell
-        $imgURL = \xan\fileBucketURL( $this->NameTable, $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ], 'PhotoFN', $recs->rowsD[ $recs->rowIndex ][ 'PhotoFN' ] );
-        $imgEle = new \xan\eleURLImage( $imgURL, ( $recs->rowIndex > 20 ? true : false ), $idListItemImage, 'Photo', 'Photo', $tagsEleInput_Photo );
-        $table->cellSet( $recs->rowIndex, 0, $tagsCellPhoto, $imgEle->render() );
-
-        // Info Cell
-        $info = '<span id="' . $idListItemLabel . '" class="list-group-item-text">' . $this->getDisplayList( $recs ) . '</span>';
-        $table->cellSet( $recs->rowIndex, 1, $tagsCellRightMiddle, $info );
-
-        // Content
-        $code = $table->render();
-        return $code;
-    }
-
-    public function getColLabel( $colName ) {
-        // Get Col Ele Meta
-        $colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-        return $colEle->colLabel;
-    }
-
-    public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
-        // Init
-        $colMeta = new \xan\colMeta();
-        $colMeta->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
-        $colMeta->eleTypeAs = $typeAs;
+	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
+		// Init
+		$colMeta = new \xan\colMeta();
+		$colMeta->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
+		$colMeta->eleTypeAs = $typeAs;
 		$colMeta->eleFormatAs = '';
-        $colMeta->colName = $colName;
-        $colMeta->colLabelEN = $colMeta->colName;
-        $colMeta->colLabel = $colMeta->colName;
-
-        // Choices
-        $colMeta->choicesAValues = [];
-        $colMeta->choicesADisplay = [];
-        $colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
-        $colMeta->choicesOtherLabel = STR_OTHER; // Add Other
-
-        // Columns Specifics
-        switch ( $colName ) {
-            case 'NameCompany':
-                $colMeta->colLabelEN = 'Company';
-                break;
-            case 'NameTitle':
-                $colMeta->colLabelEN = 'Title';
-                break;
-            case 'NamePrefix':
-                $colMeta->colLabelEN = 'Prefix';
-                $colMeta->eleType = ELE_TYPE_SELECT_DB;
-                $arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `NamePrefix` From Contacts WHERE LENGTH( `NamePrefix` ) > 0 ORDER BY `NamePrefix` ASC" );
-                $colMeta->choicesAValues = $arrays[ 0 ];
-                $colMeta->choicesADisplay = $arrays[ 0 ];
-                break;
-            case 'NameFirst':
-                $colMeta->colLabelEN = 'First Name';
-                break;
-            case 'NameMiddle':
-                $colMeta->colLabelEN = 'Middle Name';
-                break;
-            case 'NameLast':
-                $colMeta->colLabelEN = 'Last Name';
-                break;
-            case 'NameSuffix':
-                $colMeta->colLabelEN = 'Suffix';
-                $colMeta->eleType = ELE_TYPE_SELECT_DB;
-                $arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `NameSuffix` From Contacts WHERE LENGTH( `NameSuffix` ) > 0 ORDER BY `NameSuffix` ASC" );
-                $colMeta->choicesAValues = $arrays[ 0 ];
-                $colMeta->choicesADisplay = $arrays[ 0 ];
-                break;
-
-            case 'PhotoFN':
-                $colMeta->colLabelEN = 'Photo';
-                $colMeta->eleType = ELE_TYPE_FILE_BUCKET_IMAGE_DB;
-                break;
-
-            case 'Active':
-                $colMeta->colLabelEN = 'Active';
-                $colMeta->eleType = ELE_TYPE_SELECT_DB;
-                $colMeta->choicesAValues = ARRAY_YESNO;
-                $colMeta->choicesADisplay = ARRAY_YESNO;
-                $colMeta->choicesOtherLabel = '';
-                break;
-            case 'Status':
-                $colMeta->colLabelEN = 'Status';
-                $colMeta->eleType = ELE_TYPE_SELECT_DB;
-                $arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `Status` From Contacts WHERE LENGTH( `Status` ) > 0 ORDER BY `Status` ASC" );
-                $colMeta->choicesAValues = $arrays[ 0 ];
-                $colMeta->choicesADisplay = $arrays[ 0 ];
-                break;
-            case 'Type':
-                $colMeta->colLabelEN = 'Type';
-                $colMeta->eleType = ELE_TYPE_SELECT_DB;
-                $arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `Type` From Contacts WHERE LENGTH( `Type` ) > 0 ORDER BY `Type` ASC" );
-                $colMeta->choicesAValues = $arrays[ 0 ];
-                $colMeta->choicesADisplay = $arrays[ 0 ];
-                break;
-            case 'DaysToPay':
-                $colMeta->colLabelEN = 'Days To Pay';
-                $colMeta->eleType = ELE_TYPE_SELECT_DB;
-                $colMeta->choicesAValues = ARRAY_DAYSTOPAY;
-                $colMeta->choicesADisplay = ARRAY_DAYSTOPAY;
-                $colMeta->choicesOtherLabel = '';
-                break;
-            case 'State':
-                $colMeta->colLabelEN = 'Home State';
-                $colMeta->eleType = ELE_TYPE_TEXTTYPEAHEAD_DB;
-                $colMeta->choicesAValues = ARRAY_STATES_ABBREV;
-                break;
-            case 'Source':
-                $colMeta->colLabelEN = 'Source';
-                $colMeta->eleType = ELE_TYPE_SELECT_DB;
-                $arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `Source` From Contacts WHERE LENGTH( `Source` ) > 0 ORDER BY `Source` ASC" );
-                $colMeta->choicesAValues = $arrays[ 0 ];
-                $colMeta->choicesADisplay = $arrays[ 0 ];
-                break;
-
-            case 'Notes':
-                $colMeta->colLabelEN = 'Notes';
-                $colMeta->eleType = ELE_TYPE_TEXTAREA_DB;
-                break;
-            case 'ContactedDate':
-                $colMeta->colLabelEN = 'Contacted Date';
-                $colMeta->eleType = ELE_TYPE_DATE_DB;
-                break;
-            case 'TimeOpen':
-                $colMeta->colLabelEN = 'Time Open';
-                $colMeta->eleType = ELE_TYPE_TIME_DB;
-                break;
-            case 'TimeClosed':
-                $colMeta->colLabelEN = 'Time Closed';
-                $colMeta->eleType = ELE_TYPE_TIME_DB;
-                break;
-            case 'FollowUpTS':
-                $colMeta->colLabelEN = 'Follow Up At';
-                $colMeta->eleType = ELE_TYPE_DATETIME_DB;
-                break;
-            case 'FollowUpAction':
-                $colMeta->colLabelEN = 'Follow Up Action';
-                break;
-            case 'NumberInteger':
-                $colMeta->colLabelEN = 'Number Integer';
-                break;
-            case 'NumberDecimal':
-                $colMeta->colLabelEN = 'Number Decimal';
-                break;
-            case 'NumberCurrency':
-                $colMeta->colLabelEN = 'Number Currency';
-				$colMeta->eleFormatAs = ELE_FORMAT_CURRENCY;
-                break;
-
-            // Mod
-            case 'ModTS':
-                $colMeta->colLabelEN = 'Mod TS';
+		$colMeta->colName = $colName;
+		$colMeta->colLabelEN = $colMeta->colName;
+		$colMeta->colLabel = $colMeta->colName;
+		
+		// Choices
+		$colMeta->choicesAValues = [];
+		$colMeta->choicesADisplay = [];
+		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
+		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
+		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
+		// Columns Specifics
+		switch ( $colName ) {
+			case 'NameCompany':
+				$colMeta->colLabelEN = 'Company';
+				break;
+			case 'NameTitle':
+				$colMeta->colLabelEN = 'Title';
+				break;
+			case 'NamePrefix':
+				$colMeta->colLabelEN = 'Prefix';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
+				$arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `NamePrefix` From Contacts WHERE LENGTH( `NamePrefix` ) > 0 ORDER BY `NamePrefix` ASC" );
+				$colMeta->choicesAValues = $arrays[ 0 ];
+				$colMeta->choicesADisplay = $arrays[ 0 ];
+				break;
+			case 'NameFirst':
+				$colMeta->colLabelEN = 'First Name';
+				break;
+			case 'NameMiddle':
+				$colMeta->colLabelEN = 'Middle Name';
+				break;
+			case 'NameLast':
+				$colMeta->colLabelEN = 'Last Name';
+				break;
+			case 'NameSuffix':
+				$colMeta->colLabelEN = 'Suffix';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
+				$arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `NameSuffix` From Contacts WHERE LENGTH( `NameSuffix` ) > 0 ORDER BY `NameSuffix` ASC" );
+				$colMeta->choicesAValues = $arrays[ 0 ];
+				$colMeta->choicesADisplay = $arrays[ 0 ];
+				break;
+			
+			case 'PhotoFN':
+				$colMeta->colLabelEN = 'Photo';
+				$colMeta->eleType = ELE_TYPE_FILE_BUCKET_IMAGE_DB;
+				break;
+			
+			case 'Active':
+				$colMeta->colLabelEN = 'Active';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
+				$colMeta->choicesAValues = ARRAY_YESNO;
+				$colMeta->choicesADisplay = ARRAY_YESNO;
+				$colMeta->choicesOtherLabel = '';
+				break;
+			case 'Status':
+				$colMeta->colLabelEN = 'Status';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
+				$arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `Status` From Contacts WHERE LENGTH( `Status` ) > 0 ORDER BY `Status` ASC" );
+				$colMeta->choicesAValues = $arrays[ 0 ];
+				$colMeta->choicesADisplay = $arrays[ 0 ];
+				break;
+			case 'Type':
+				$colMeta->colLabelEN = 'Type';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
+				$arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `Type` From Contacts WHERE LENGTH( `Type` ) > 0 ORDER BY `Type` ASC" );
+				$colMeta->choicesAValues = $arrays[ 0 ];
+				$colMeta->choicesADisplay = $arrays[ 0 ];
+				break;
+			case 'DaysToPay':
+				$colMeta->colLabelEN = 'Days To Pay';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
+				$colMeta->choicesAValues = ARRAY_DAYSTOPAY;
+				$colMeta->choicesADisplay = ARRAY_DAYSTOPAY;
+				$colMeta->choicesOtherLabel = '';
+				break;
+			case 'State':
+				$colMeta->colLabelEN = 'Home State';
+				$colMeta->eleType = ELE_TYPE_TEXTTYPEAHEAD_DB;
+				$colMeta->choicesAValues = ARRAY_STATES_ABBREV;
+				break;
+			case 'Source':
+				$colMeta->colLabelEN = 'Source';
+				$colMeta->eleType = ELE_TYPE_SELECT_DB;
+				$arrays = \xan\choicesAFromSQLCols( $this->NameTable, "SELECT DISTINCT `Source` From Contacts WHERE LENGTH( `Source` ) > 0 ORDER BY `Source` ASC" );
+				$colMeta->choicesAValues = $arrays[ 0 ];
+				$colMeta->choicesADisplay = $arrays[ 0 ];
+				break;
+			
+			case 'Notes':
+				$colMeta->colLabelEN = 'Notes';
+				$colMeta->eleType = ELE_TYPE_TEXTAREA_DB;
+				break;
+			case 'ContactedDate':
+				$colMeta->colLabelEN = 'Contacted Date';
+				$colMeta->eleType = ELE_TYPE_DATE_DB;
+				break;
+			case 'TimeOpen':
+				$colMeta->colLabelEN = 'Time Open';
+				$colMeta->eleType = ELE_TYPE_TIME_DB;
+				break;
+			case 'TimeClosed':
+				$colMeta->colLabelEN = 'Time Closed';
+				$colMeta->eleType = ELE_TYPE_TIME_DB;
+				break;
+			case 'FollowUpTS':
+				$colMeta->colLabelEN = 'Follow Up At';
 				$colMeta->eleType = ELE_TYPE_DATETIME_DB;
-                $colMeta->isMod = true;
-                break;
-            case 'ModName':
-                $colMeta->colLabelEN = 'Mod Name';
-                $colMeta->isMod = true;
-                break;
-            case 'ModUUIDUsers':
-                $colMeta->colLabelEN = 'Mod Users ID';
-                $colMeta->isMod = true;
-                $colMeta->isKey = true;
-                break;
-
-            // UUID
-            case 'UUIDContacts':
-                $colMeta->colLabelEN = 'Contacts ID';
-                $colMeta->isKey = true;
-                $colMeta->isKeyPrimary = true;
-                $colMeta->isKeyForeign = false;
-                break;
-        }
-
-        // Set the Label
-        $colMeta->colLabel = $colMeta->colLabelEN;
-
-        // Return the Element
-        return $colMeta;
-    }
-
-    public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-        // Get Col Ele Meta
-        $colMeta = $this->getColMeta( $colName, $typeAs );
-        $code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-        return $code;
-    }
-
-
-    ///////////////////////////////////////////////////////////
-    // Functions For This Module
+				break;
+			case 'FollowUpAction':
+				$colMeta->colLabelEN = 'Follow Up Action';
+				break;
+			case 'NumberInteger':
+				$colMeta->colLabelEN = 'Number Integer';
+				break;
+			case 'NumberDecimal':
+				$colMeta->colLabelEN = 'Number Decimal';
+				break;
+			case 'NumberCurrency':
+				$colMeta->colLabelEN = 'Number Currency';
+				$colMeta->eleFormatAs = ELE_FORMAT_CURRENCY;
+				break;
+			
+			// Mod
+			case 'ModTS':
+				$colMeta->colLabelEN = 'Mod TS';
+				$colMeta->eleType = ELE_TYPE_DATETIME_DB;
+				$colMeta->isMod = true;
+				break;
+			case 'ModName':
+				$colMeta->colLabelEN = 'Mod Name';
+				$colMeta->isMod = true;
+				break;
+			case 'ModUUIDUsers':
+				$colMeta->colLabelEN = 'Mod Users ID';
+				$colMeta->isMod = true;
+				$colMeta->isKey = true;
+				break;
+			
+			// UUID
+			case 'UUIDContacts':
+				$colMeta->colLabelEN = 'Contacts ID';
+				$colMeta->isKey = true;
+				$colMeta->isKeyPrimary = true;
+				$colMeta->isKeyForeign = false;
+				break;
+		}
+		
+		// Set the Label
+		$colMeta->colLabel = $colMeta->colLabelEN;
+		
+		// Return the Element
+		return $colMeta;
+	}
+	
+	
+	///////////////////////////////////////////////////////////
+	// Functions For This Module
 }
 
 

--- a/app/zzMetaModules/mmHome.php
+++ b/app/zzMetaModules/mmHome.php
@@ -30,7 +30,7 @@ class moduleMetaHome extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -42,17 +42,6 @@ class moduleMetaHome extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -71,10 +60,13 @@ class moduleMetaHome extends \xan\moduleMeta {
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
 		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'NULL':
-				$colEle->colLabelEN = 'NULL';
+				$colMeta->colLabelEN = 'NULL';
 				break;
 		}
 		
@@ -84,14 +76,6 @@ class moduleMetaHome extends \xan\moduleMeta {
 		// Return the Element
 		return $colMeta;
 	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
-	}
-	
 	
 	///////////////////////////////////////////////////////////
 	// Functions For This Module

--- a/app/zzMetaModules/mmLogAuditT.php
+++ b/app/zzMetaModules/mmLogAuditT.php
@@ -30,7 +30,7 @@ class moduleMetaLogAuditT extends \xan\moduleMeta {
 
 
     ///////////////////////////////////////////////////////////
-    // Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 
     public function getDisplayList( \xan\recs $recs ) {
         $code = $this->getDisplayName( $recs );
@@ -43,87 +43,73 @@ class moduleMetaLogAuditT extends \xan\moduleMeta {
         $code = trim( $code );
         return $code;
     }
-
-    public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-        $code = '';
-        return $code;
-    }
-
-    public function getColLabel( $colName ) {
-        // Get Col Ele Meta
-        $colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-        return $colEle->colLabel;
-    }
+    
 
     public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
         // Init
-        $colEle = new \xan\colMeta();
-        $colEle->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
-        $colEle->eleTypeAs = $typeAs;
-        $colEle->colName = $colName;
-        $colEle->colLabelEN = $colEle->colName;
-        $colEle->colLabel = $colEle->colName;
+        $colMeta = new \xan\colMeta();
+        $colMeta->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
+        $colMeta->eleTypeAs = $typeAs;
+        $colMeta->colName = $colName;
+        $colMeta->colLabelEN = $colMeta->colName;
+        $colMeta->colLabel = $colMeta->colName;
 
         // Choices
-        $colEle->choicesAValues = [];
-        $colEle->choicesADisplay = [];
-        $colEle->choicesClearLabel = STR_CLEAR; // Add Clear
-        $colEle->choicesOtherLabel = STR_OTHER; // Add Other
-
+        $colMeta->choicesAValues = [];
+        $colMeta->choicesADisplay = [];
+        $colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
+        $colMeta->choicesOtherLabel = STR_OTHER; // Add Other
+	
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
         // Columns Specifics
         switch ( $colName ) {
             case 'Action':
-                $colEle->colLabelEN = 'Action';
+                $colMeta->colLabelEN = 'Action';
                 break;
             case 'TableName':
-                $colEle->colLabelEN = 'Table Name';
+                $colMeta->colLabelEN = 'Table Name';
                 break;
             case 'TableUUIDName':
-                $colEle->colLabelEN = 'Table Key Name';
+                $colMeta->colLabelEN = 'Table Key Name';
                 break;
             case 'TableUUID':
-                $colEle->colLabelEN = 'Table Key Value';
+                $colMeta->colLabelEN = 'Table Key Value';
                 break;
             case 'FieldValues':
-                $colEle->colLabelEN = 'Field Values';
+                $colMeta->colLabelEN = 'Field Values';
                 break;
 	
 			// Mod
 			case 'ModTS':
-				$colEle->colLabelEN = 'Mod TS';
-				$colEle->isMod = true;
+				$colMeta->colLabelEN = 'Mod TS';
+				$colMeta->isMod = true;
 				break;
 			case 'ModName':
-				$colEle->colLabelEN = 'Mod Name';
-				$colEle->isMod = true;
+				$colMeta->colLabelEN = 'Mod Name';
+				$colMeta->isMod = true;
 				break;
 			case 'ModUUIDUsers':
-				$colEle->colLabelEN = 'Mod Users ID';
-				$colEle->isMod = true;
-				$colEle->isKey = true;
+				$colMeta->colLabelEN = 'Mod Users ID';
+				$colMeta->isMod = true;
+				$colMeta->isKey = true;
 				break;
 
             // UUID
             case 'UUIDLogAudit':
-                $colEle->colLabelEN = 'Log Audit ID';
-                $colEle->isKey = true;
-                $colEle->isKeyPrimary = true;
-                $colEle->isKeyForeign = false;
+                $colMeta->colLabelEN = 'Log Audit ID';
+                $colMeta->isKey = true;
+                $colMeta->isKeyPrimary = true;
+                $colMeta->isKeyForeign = false;
                 break;
         }
 
         // Set the Label
-        $colEle->colLabel = $colEle->colLabelEN;
+        $colMeta->colLabel = $colMeta->colLabelEN;
 
         // Return the Element
-        return $colEle;
-    }
-
-    public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-        // Get Col Ele Meta
-        $colEle = $this->getColMeta( $colName, $typeAs );
-        $code = \xan\eleDBMetaRender( $colEle, $tags, $recs, $formTag, $resp );
-        return $code;
+        return $colMeta;
     }
 
 

--- a/app/zzMetaModules/mmLogEventT.php
+++ b/app/zzMetaModules/mmLogEventT.php
@@ -30,7 +30,7 @@ class moduleMetaLogEventT extends \xan\moduleMeta {
 
 
     ///////////////////////////////////////////////////////////
-    // Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 
     public function getDisplayList( \xan\recs $recs ) {
         $code = $this->getDisplayName( $recs );
@@ -44,80 +44,65 @@ class moduleMetaLogEventT extends \xan\moduleMeta {
         return $code;
     }
 
-    public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-        $code = '';
-        return $code;
-    }
-
-    public function getColLabel( $colName ) {
-        // Get Col Ele Meta
-        $colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-        return $colEle->colLabel;
-    }
-
     public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
         // Init
-        $colEle = new \xan\colMeta();
-        $colEle->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
-        $colEle->eleTypeAs = $typeAs;
-        $colEle->colName = $colName;
-        $colEle->colLabelEN = $colEle->colName;
-        $colEle->colLabel = $colEle->colName;
+        $colMeta = new \xan\colMeta();
+        $colMeta->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
+        $colMeta->eleTypeAs = $typeAs;
+        $colMeta->colName = $colName;
+        $colMeta->colLabelEN = $colMeta->colName;
+        $colMeta->colLabel = $colMeta->colName;
 
         // Choices
-        $colEle->choicesAValues = [];
-        $colEle->choicesADisplay = [];
-        $colEle->choicesClearLabel = STR_CLEAR; // Add Clear
-        $colEle->choicesOtherLabel = STR_OTHER; // Add Other
-
+        $colMeta->choicesAValues = [];
+        $colMeta->choicesADisplay = [];
+        $colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
+        $colMeta->choicesOtherLabel = STR_OTHER; // Add Other
+	
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
         // Columns Specifics
         switch ( $colName ) {
             case 'EventTS':
-                $colEle->colLabelEN = 'Event Timestamp';
+                $colMeta->colLabelEN = 'Event Timestamp';
                 break;
             case 'Login':
-                $colEle->colLabelEN = 'Login';
+                $colMeta->colLabelEN = 'Login';
                 break;
             case 'PageName':
-                $colEle->colLabelEN = 'Page Name';
+                $colMeta->colLabelEN = 'Page Name';
                 break;
             case 'Type':
-                $colEle->colLabelEN = 'Type';
+                $colMeta->colLabelEN = 'Type';
                 break;
             case 'Desc1':
-                $colEle->colLabelEN = 'Desc 1';
+                $colMeta->colLabelEN = 'Desc 1';
                 break;
             case 'Desc2':
-                $colEle->colLabelEN = 'Desc 2';
+                $colMeta->colLabelEN = 'Desc 2';
                 break;
 
             // UUID
             case 'UUIDLogEvent':
-                $colEle->colLabelEN = 'Log Event ID';
-                $colEle->isKey = true;
-                $colEle->isKeyPrimary = true;
-                $colEle->isKeyForeign = false;
+                $colMeta->colLabelEN = 'Log Event ID';
+                $colMeta->isKey = true;
+                $colMeta->isKeyPrimary = true;
+                $colMeta->isKeyForeign = false;
                 break;
             case 'UUIDUsers':
-                $colEle->colLabelEN = 'User ID';
-                $colEle->isKey = true;
-                $colEle->isKeyPrimary = false;
-                $colEle->isKeyForeign = true;
+                $colMeta->colLabelEN = 'User ID';
+                $colMeta->isKey = true;
+                $colMeta->isKeyPrimary = false;
+                $colMeta->isKeyForeign = true;
                 break;
         }
 
         // Set the Label
-        $colEle->colLabel = $colEle->colLabelEN;
+        $colMeta->colLabel = $colMeta->colLabelEN;
 
         // Return the Element
-        return $colEle;
-    }
-
-    public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-        // Get Col Ele Meta
-        $colEle = $this->getColMeta( $colName, $typeAs );
-        $code = \xan\eleDBMetaRender( $colEle, $tags, $recs, $formTag, $resp );
-        return $code;
+        return $colMeta;
     }
 
 

--- a/app/zzMetaModules/mmNullT.php
+++ b/app/zzMetaModules/mmNullT.php
@@ -30,7 +30,7 @@ class moduleMetaNullT extends \xan\moduleMeta {
 
 
     ///////////////////////////////////////////////////////////
-    // Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 
     public function getDisplayList( \xan\recs $recs ) {
         $code = $this->getDisplayName( $recs );
@@ -44,53 +44,38 @@ class moduleMetaNullT extends \xan\moduleMeta {
         return $code;
     }
 
-    public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-        $code = '';
-        return $code;
-    }
-
-    public function getColLabel( $colName ) {
-        // Get Col Ele Meta
-        $colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-        return $colEle->colLabel;
-    }
-
     public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
         // Init
-        $colEle = new \xan\colMeta();
-        $colEle->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
-        $colEle->eleTypeAs = $typeAs;
-        $colEle->colName = $colName;
-        $colEle->colLabelEN = $colEle->colName;
-        $colEle->colLabel = $colEle->colName;
+        $colMeta = new \xan\colMeta();
+        $colMeta->eleType = ELE_TYPE_TEXT_DB; // Default to Text Input
+        $colMeta->eleTypeAs = $typeAs;
+        $colMeta->colName = $colName;
+        $colMeta->colLabelEN = $colMeta->colName;
+        $colMeta->colLabel = $colMeta->colName;
 
         // Choices
-        $colEle->choicesAValues = [];
-        $colEle->choicesADisplay = [];
-        $colEle->choicesClearLabel = STR_CLEAR; // Add Clear
-        $colEle->choicesOtherLabel = STR_OTHER; // Add Other
-
+        $colMeta->choicesAValues = [];
+        $colMeta->choicesADisplay = [];
+        $colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
+        $colMeta->choicesOtherLabel = STR_OTHER; // Add Other
+	
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
         // Columns Specifics
         switch ( $colName ) {
             case 'NULL':
-                $colEle->colLabelEN = 'NULL';
+                $colMeta->colLabelEN = 'NULL';
                 break;
         }
 
         // Set the Label
-        $colEle->colLabel = $colEle->colLabelEN;
+        $colMeta->colLabel = $colMeta->colLabelEN;
 
         // Return the Element
-        return $colEle;
+        return $colMeta;
     }
-
-    public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-        // Get Col Ele Meta
-        $colEle = $this->getColMeta( $colName, $typeAs );
-        $code = \xan\eleDBMetaRender( $colEle, $tags, $recs, $formTag, $resp );
-        return $code;
-    }
-
+    
 
     ///////////////////////////////////////////////////////////
     // Functions For This Module

--- a/app/zzMetaModules/mmServer404.php
+++ b/app/zzMetaModules/mmServer404.php
@@ -33,7 +33,7 @@ class moduleMetaServer404 extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -45,17 +45,6 @@ class moduleMetaServer404 extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -74,10 +63,13 @@ class moduleMetaServer404 extends \xan\moduleMeta {
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
 		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'NULL':
-				$colEle->colLabelEN = 'NULL';
+				$colMeta->colLabelEN = 'NULL';
 				break;
 		}
 		
@@ -86,13 +78,6 @@ class moduleMetaServer404 extends \xan\moduleMeta {
 		
 		// Return the Element
 		return $colMeta;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
 	}
 	
 	

--- a/app/zzMetaModules/mmServerStats.php
+++ b/app/zzMetaModules/mmServerStats.php
@@ -33,7 +33,7 @@ class moduleMetaServerStats extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -45,17 +45,6 @@ class moduleMetaServerStats extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -74,10 +63,13 @@ class moduleMetaServerStats extends \xan\moduleMeta {
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
 		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'NULL':
-				$colEle->colLabelEN = 'NULL';
+				$colMeta->colLabelEN = 'NULL';
 				break;
 		}
 		
@@ -86,13 +78,6 @@ class moduleMetaServerStats extends \xan\moduleMeta {
 		
 		// Return the Element
 		return $colMeta;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
 	}
 	
 	

--- a/app/zzMetaModules/mmSettingsT.php
+++ b/app/zzMetaModules/mmSettingsT.php
@@ -33,7 +33,7 @@ class moduleMetaSettingsT extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -45,17 +45,6 @@ class moduleMetaSettingsT extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -73,6 +62,9 @@ class moduleMetaSettingsT extends \xan\moduleMeta {
 		$colMeta->choicesADisplay = [];
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
+		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
 		
 		// Columns Specifics
 		switch ( $colName ) {
@@ -221,13 +213,6 @@ class moduleMetaSettingsT extends \xan\moduleMeta {
 		
 		// Return the Element
 		return $colMeta;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
 	}
 	
 	

--- a/app/zzMetaModules/mmUsersLogin.php
+++ b/app/zzMetaModules/mmUsersLogin.php
@@ -33,7 +33,7 @@ class moduleMetaUsersLogin extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -45,17 +45,6 @@ class moduleMetaUsersLogin extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -74,10 +63,13 @@ class moduleMetaUsersLogin extends \xan\moduleMeta {
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
 		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'NULL':
-				$colEle->colLabelEN = 'NULL';
+				$colMeta->colLabelEN = 'NULL';
 				break;
 		}
 		
@@ -86,13 +78,6 @@ class moduleMetaUsersLogin extends \xan\moduleMeta {
 		
 		// Return the Element
 		return $colMeta;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
 	}
 	
 	

--- a/app/zzMetaModules/mmUsersLogout.php
+++ b/app/zzMetaModules/mmUsersLogout.php
@@ -33,7 +33,7 @@ class moduleMetaUsersLogout extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -45,17 +45,6 @@ class moduleMetaUsersLogout extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -74,10 +63,13 @@ class moduleMetaUsersLogout extends \xan\moduleMeta {
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
 		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'NULL':
-				$colEle->colLabelEN = 'NULL';
+				$colMeta->colLabelEN = 'NULL';
 				break;
 		}
 		
@@ -86,13 +78,6 @@ class moduleMetaUsersLogout extends \xan\moduleMeta {
 		
 		// Return the Element
 		return $colMeta;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
 	}
 	
 	

--- a/app/zzMetaModules/mmUsersPasswordReset.php
+++ b/app/zzMetaModules/mmUsersPasswordReset.php
@@ -33,7 +33,7 @@ class moduleMetaUsersPasswordReset extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -45,17 +45,6 @@ class moduleMetaUsersPasswordReset extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -74,10 +63,13 @@ class moduleMetaUsersPasswordReset extends \xan\moduleMeta {
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
 		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'NULL':
-				$colEle->colLabelEN = 'NULL';
+				$colMeta->colLabelEN = 'NULL';
 				break;
 		}
 		
@@ -87,14 +79,6 @@ class moduleMetaUsersPasswordReset extends \xan\moduleMeta {
 		// Return the Element
 		return $colMeta;
 	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
-	}
-	
 	
 	///////////////////////////////////////////////////////////
 	// Functions For This Module

--- a/app/zzMetaModules/mmUsersRegister.php
+++ b/app/zzMetaModules/mmUsersRegister.php
@@ -33,7 +33,7 @@ class moduleMetaUsersRegister extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayList( \xan\recs $recs ) {
 		$code = $this->getDisplayName( $recs );
@@ -45,17 +45,6 @@ class moduleMetaUsersRegister extends \xan\moduleMeta {
 		$code = '';
 		$code = trim( $code );
 		return $code;
-	}
-	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$code = '';
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
 	}
 	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
@@ -74,10 +63,13 @@ class moduleMetaUsersRegister extends \xan\moduleMeta {
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
 		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
+		
 		// Columns Specifics
 		switch ( $colName ) {
 			case 'NULL':
-				$colEle->colLabelEN = 'NULL';
+				$colMeta->colLabelEN = 'NULL';
 				break;
 		}
 		
@@ -87,14 +79,6 @@ class moduleMetaUsersRegister extends \xan\moduleMeta {
 		// Return the Element
 		return $colMeta;
 	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
-	}
-	
 	
 	///////////////////////////////////////////////////////////
 	// Functions For This Module

--- a/app/zzMetaModules/mmUsersT.php
+++ b/app/zzMetaModules/mmUsersT.php
@@ -36,7 +36,7 @@ class moduleMetaUsersT extends \xan\moduleMeta {
 	
 	
 	///////////////////////////////////////////////////////////
-	// Functions Required by \xan\moduleMeta
+	// Abstract Functions Required by \xan\moduleMeta
 	
 	public function getDisplayName( \xan\recs $recs ) {
 		// Name
@@ -73,30 +73,6 @@ class moduleMetaUsersT extends \xan\moduleMeta {
 		return $code;
 	}
 	
-	public function getListItem( $idPrefix, \xan\recs $recs, $onClick ) {
-		$idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ];
-		$idListItemLabel = $idListItem . 'Label';
-		
-		// Table Init
-		$tagsCellEmpty = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_MIDDLE ], [], [] );
-		$tagsCellRightMiddle = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [], [] );
-		$table = new \xan\eleTable( $tagsCellEmpty );
-		
-		// Info Cell
-		$info = '<span id="' . $idListItemLabel . '" class="list-group-item-text">' . $this->getDisplayList( $recs ) . '</span>';
-		$table->cellSet( $recs->rowIndex, 0, $tagsCellRightMiddle, $info );
-		
-		// Content
-		$code = $table->render();
-		return $code;
-	}
-	
-	public function getColLabel( $colName ) {
-		// Get Col Ele Meta
-		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
-		return $colEle->colLabel;
-	}
-	
 	public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED ) {
 		// Init
 		$colMeta = new \xan\colMeta();
@@ -112,6 +88,9 @@ class moduleMetaUsersT extends \xan\moduleMeta {
 		$colMeta->choicesADisplay = [];
 		$colMeta->choicesClearLabel = STR_CLEAR; // Add Clear
 		$colMeta->choicesOtherLabel = STR_OTHER; // Add Other
+		
+		// Sizes
+		$colMeta->widthForTable = ''; // No Default for Overrides Closer to Renderers
 		
 		// Columns Specifics
 		switch ( $colName ) {
@@ -235,13 +214,6 @@ class moduleMetaUsersT extends \xan\moduleMeta {
 		
 		// Return the Element
 		return $colMeta;
-	}
-	
-	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
-		// Get Col Ele Meta
-		$colMeta = $this->getColMeta( $colName, $typeAs );
-		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
-		return $code;
 	}
 	
 	

--- a/templates/page-resp.php
+++ b/templates/page-resp.php
@@ -445,7 +445,7 @@ ob_start();
                 data: "params=" + encodeURIComponent( JSON.stringify( params ) ),
                 success: function ( successResult, status, xhr ) {
                     // JSON Get
-                    // alert( "xanDo Success: " + successResult );
+                    alert( "xanDo Success: " + successResult );
                     if ( successResult === "" ) {
                         alert( "Error: xanDo Result is Blank; Params: " + JSON.stringify( params ) );
                         return;

--- a/xan/class-xan.php
+++ b/xan/class-xan.php
@@ -321,11 +321,128 @@ abstract class moduleMeta {
 	// Functions
 	abstract public function getDisplayName( recs $recs );
 	abstract public function getDisplayList( recs $recs );
-	abstract public function getListItem( $idPrefix, recs $recs, $onClick );
-	abstract public function getColLabel( $colName );
-	abstract public function getColEleRender( $colName, $typeAs, tags $tags, recs $recs, formTag $formTag, response &$resp );
 	abstract public function getColMeta( $colName, $typeAs = ELE_AS_DEFINED );
+	
+	public function getColLabel( $colName ) {
+		// Get Col Ele Meta
+		$colEle = $this->getColMeta( $colName, ELE_AS_LABEL );
+		return $colEle->colLabel;
+	}
+	
+	public function getColEleRender( $colName, $typeAs, \xan\tags $tags, \xan\recs $recs, \xan\formTag $formTag, \xan\response &$resp ) {
+		// Get Col Ele Meta
+		$colMeta = $this->getColMeta( $colName, $typeAs );
+		$code = \xan\eleDBMetaRender( $colMeta, $tags, $recs, $formTag, $resp );
+		return $code;
+	}
+	
+	public function getListItem( \xan\recs $recs, $idPrefix, $idSelected, $onClick ) {
+	    // IDs Init
+		$idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ];
+		$idListItemLabel = $idListItem . 'Label';
+		
+		// Table Init
+		$tagsCellEmpty = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_MIDDLE ], [], [] );
+		$tagsCellRightMiddle = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [], [] );
+		$table = new \xan\eleTable( $tagsCellEmpty );
+		
+		// Info Cell
+		$info = $this->getDisplayList( $recs );
+		$info = '<span id="' . $idListItemLabel . '" class="list-group-item-text">' . $info . '</span>';
+		$table->cellSet( $recs->rowIndex, 1, $tagsCellRightMiddle, $info );
+		
+		// Content
+		$content = $table->render();
+		
+		$active = ( $idSelected == $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ] ? 'active' : '' );
+		$content = str_replace( 'list-group-item-text', 'list-group-item-text ' . $active, $content );
+		$code = <<< HTML
+        <span id="{$idListItem}" class="list-group-item list-group-item-action {$active} border-secondary border-bottom p-1 pt-2 pb-2" onclick="{$onClick}">
+		{$content}<div style="position: absolute; top: 2px; right: 2px; font-size: 9px;">{$recs->rowIndex}</div></span>
+HTML;
+		return $code;
+	}
+	
+		public function getListItemWImage( \xan\recs $recs, $idPrefix, $idSelected, $onClick,\xan\tags $tagsCellImage,\xan\eleURLImage $imageEle ) {
+	    // IDs Init
+		$idListItem = $idPrefix . $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ];
+		$idListItemLabel = $idListItem . 'Label';
+		
+		// Table Init
+		$tagsCellEmpty = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_MIDDLE ], [], [] );
+		$tagsCellRightMiddle = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [], [] );
+		$table = new \xan\eleTable( $tagsCellEmpty );
+		
+		// Image Cell
+		$table->cellSet( $recs->rowIndex, 0, $tagsCellImage, $imageEle->render() );
+		
+		// Info Cell
+		$info = $this->getDisplayList( $recs );
+		$info = '<span id="' . $idListItemLabel . '" class="list-group-item-text">' . $info . '</span>';
+		$table->cellSet( $recs->rowIndex, 1, $tagsCellRightMiddle, $info );
+		
+		// Content
+		$content = $table->render();
+		
+		$active = ( $idSelected == $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ] ? 'active' : '' );
+		$content = str_replace( 'list-group-item-text', 'list-group-item-text ' . $active, $content );
+		$code = <<< HTML
+        <span id="{$idListItem}" class="list-group-item list-group-item-action {$active} border-secondary border-bottom p-1 pt-2 pb-2" onclick="{$onClick}">
+		{$content}<div style="position: absolute; top: 2px; right: 2px; font-size: 9px;">{$recs->rowIndex}</div></span>
+HTML;
+		return $code;
+	}
+	
+	public function getListRow( $rowType, \xan\recs $recs, \xan\eleTable &$table, $bodyIDPrefix, $bodyIDSelected, $bodyOnClick, $bodyRowHeight, $bodyColWidth ) {
+		if ( $rowType === 'head' ) {
+			// Init Indexes
+			// Init Indexes
+			$colIndex = 0;
+			
+			// Cell Tag
+			$tagsCell = new \xan\tags( [ 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [ 'position' => '-webkit-sticky', 'position' => '-moz-sticky', 'position' => '-ms-sticky', 'position' => '-o-sticky', 'position' => 'sticky', 'top' => 0 ], [] );
+			
+			// Cell Left
+			$table->cellSet( $recs->rowIndex, $colIndex, $tagsCell, '' );
+		}
+		
+		if ( $rowType === 'body' ) {
+			// Init Indexes
+			$colIndex = 0;
+			$rowIndexTable = $recs->rowIndex + 1;
+			
+			// Cell Tag
+			$isActive = ( $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ] === $bodyIDSelected ? 'active' : '' );
+			$tagsCell = new \xan\tags( [ $isActive, 'border-0', 'pb-0', TEXT_ALIGN_LEFT, TABLE_ALIGN_TOP ], [], [] );
+			
+			// Cell Left
+			$idListItem = $bodyIDPrefix . $recs->rowsD[ $recs->rowIndex ][ $this->NameTableKey ];
+			$buttonMoreTags = new \xan\tags( [ ELE_CLASS_BUTTON_SM_SECONDARY, 'mb-2' ], [], [ 'id="' . $idListItem . '"', 'onclick="' . $bodyOnClick . '"' ] );
+			$buttonMoreEle = new \xan\eleButton( $rowIndexTable, '', '', $buttonMoreTags );
+			$table->cellSet( $rowIndexTable, $colIndex, $tagsCell, '<div style="height: ' . $bodyRowHeight . '; overflow-y: auto;">' . $buttonMoreEle->render() . '</div>' );
+		}
+		
+		// For Each Header or Data Row Cell
+		foreach ( $recs->rowsD[ $recs->rowIndex ] as $key => $value ) {
+			$colIndex++;
+			
+			// Get Col Meta
+			$keyColMeta = $this->getColMeta( $key );
+			
+			if ( $rowType === 'head' ) {
+				$table->cellSet( $recs->rowIndex, $colIndex, $tagsCell, $keyColMeta->colLabel );
+			}
+			
+			if ( $rowType === 'body' ) {
+				$width = ( \xan\isEmpty( $keyColMeta->widthForTable) ? $bodyColWidth : $keyColMeta->widthForTable );
+				$table->cellSet( $rowIndexTable, $colIndex, $tagsCell, '<div style="height: ' . $bodyRowHeight . '; width: ' . $width . '; overflow-y: auto;">' . $value . '</div>' );
+			}
+		}
+		
+	}
+	
 }
+
 
 // recsQuerySimple
 function recsQuerySimple( $sql, $bindNamesA, $bindValuesA ){
@@ -878,6 +995,8 @@ class colMeta {
 	public $colName = '';
 	public $colLabelEN = '';
 	public $colLabel = '';
+	
+	public $widthForTable = '';
 
 	public $isMod = false;
 	public $isKey = false;


### PR DESCRIPTION
- Summary: Simplifying List Cards while adding options: Items Text, Items Image + Text, or a Table Row.
- Removed three functions from moduleMeta class and each subclass. Replaced with sharable moduleMeta functions.
- Added colMeta property widthForTable that defaults to empty string but can be overridden per Table Column Name.
- Added two new moduleMeta getList functions: getListItem is for text, getListItemWImage is for an image + text, and getListRow is for html tables at full page width with a default column width.
- Updated content-cards.php Lists for Contacts, Contact Picker ( image + text ), Settings-Users ( text ), and APIRequests ( html table ). It's now easy to change how Lists are displayed.